### PR TITLE
Allowed 72 characters in commit header

### DIFF
--- a/doc/commit-style.md
+++ b/doc/commit-style.md
@@ -36,7 +36,7 @@ Initial commit
 
 - Length
 
-  Commonly accepted 50/72 rule is used to format commits. 50 is the maximum number of characters of the commit title and 72 is the maximum character length of the commit body
+  The maximum number of characters in a commit header is __72__ (standard for __Git__). Additionally, __72__ is the maximum length of a line in a commit body.
 
 - Categories
 


### PR DESCRIPTION
### Proposed changes

The commit styling rule has been corrected in the documentation. __50__ characters for a commit header is very few, including due to the prefix. You can now use __72__ characters (standard __Git__ limit)

### Associated issues

- 

### Testing

-

### Agreements

- [x] I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md)
- [x] I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md)
