### PR TITLE
Enabled of jwasm for building

### DIFF
--- a/.github/workflows/build-system.yaml
+++ b/.github/workflows/build-system.yaml
@@ -73,6 +73,10 @@ jobs:
           wget https://github.com/kolibrios-nextgen/kolibrios-nextgen/releases/download/v1.0/kos32-tcc -O /home/autobuild/tools/win32/bin/kos32-tcc
           chmod +x /home/autobuild/tools/win32/bin/kos32-tcc
 
+          # Get jwasm
+          wget https://github.com/kolibrios-nextgen/kolibrios-nextgen/releases/download/v1.0/jwasm -O /home/autobuild/tools/win32/bin/jwasm
+          chmod +x /home/autobuild/tools/win32/bin/jwasm
+
       - name: Compile objconv
         run: |
           source ~/.bashrc
@@ -113,7 +117,6 @@ jobs:
           export ROOT=${{ github.workspace }}
           cd $ROOT
           echo "CONFIG_LANG=en"                                                           >> tup.config
-          echo "CONFIG_NO_JWASM=full"                                                     >> tup.config
           echo "CONFIG_NO_MSVC=full"                                                      >> tup.config
           echo "CONFIG_TOOLCHAIN_LIBPATH=/home/autobuild/tools/win32/mingw32/lib"         >> tup.config
           echo 'CONFIG_KPACK_CMD=&& kpack --nologo "%o"'                                  >> tup.config
@@ -155,7 +158,6 @@ jobs:
           export ROOT=${{ github.workspace }}
           cd $ROOT
           echo "CONFIG_LANG=ru"                                                            > tup.config
-          echo "CONFIG_NO_JWASM=full"                                                     >> tup.config
           echo "CONFIG_NO_MSVC=full"                                                      >> tup.config
           echo "CONFIG_TOOLCHAIN_LIBPATH=/home/autobuild/tools/win32/mingw32/lib"         >> tup.config
           echo 'CONFIG_KPACK_CMD=&& kpack --nologo "%o"'                                  >> tup.config

--- a/Dockerfile.build-eng
+++ b/Dockerfile.build-eng
@@ -19,7 +19,6 @@ RUN \
     export PATH=/home/autobuild/tools/win32/bin:$PATH && \
     export ROOT=/src && \
     echo "CONFIG_LANG=en" >> tup.config && \
-    echo "CONFIG_NO_JWASM=full" >> tup.config && \
     echo "CONFIG_NO_MSVC=full" >> tup.config && \
     echo "CONFIG_TOOLCHAIN_LIBPATH=/home/autobuild/tools/win32/mingw32/lib" >> tup.config && \
     echo 'CONFIG_KPACK_CMD=&& kpack --nologo "%o"' >> tup.config && \

--- a/Dockerfile.build-rus
+++ b/Dockerfile.build-rus
@@ -19,7 +19,6 @@ RUN \
     export PATH=/home/autobuild/tools/win32/bin:$PATH && \
     export ROOT=/src && \
     echo "CONFIG_LANG=ru" >> tup.config && \
-    echo "CONFIG_NO_JWASM=full" >> tup.config && \
     echo "CONFIG_NO_MSVC=full" >> tup.config && \
     echo "CONFIG_TOOLCHAIN_LIBPATH=/home/autobuild/tools/win32/mingw32/lib" >> tup.config && \
     echo 'CONFIG_KPACK_CMD=&& kpack --nologo "%o"' >> tup.config && \

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -49,7 +49,9 @@ RUN \
     chmod go-w /usr/lib/x86_64-linux-gnu/libisl.so.10.2.2 && \
     cd /src && \
     wget https://github.com/kolibrios-nextgen/kolibrios-nextgen/releases/download/v1.0/kos32-tcc -O /home/autobuild/tools/win32/bin/kos32-tcc && \
-    chmod +x /home/autobuild/tools/win32/bin/kos32-tcc
+    chmod +x /home/autobuild/tools/win32/bin/kos32-tcc \
+    wget https://github.com/kolibrios-nextgen/kolibrios-nextgen/releases/download/v1.0/jwasm -O /home/autobuild/tools/win32/bin/jwasm \
+    chmod +x /home/autobuild/tools/win32/bin/jwasm
 
 # Compile parts of toolchain
 RUN \


### PR DESCRIPTION
### Proposed changes

- Use jwasm in CI/CD
- Use jwasm for docker build

### Associated issues

- #59 

### Testing

- [x] Check the presence and functionality of the `run` program in the `en_US` and `ru_RU` floppy disk images.

### Agreements

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md)
